### PR TITLE
feat: 添加消减卡顿功能到时间戳工具菜单

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -324,7 +324,11 @@
 			"autoSegment": "Auto Segment",
 			"rubySegment": "Ruby Segmentation",
 			"advancedSegment": "Advanced Segment...",
-			"syncLineTimestamps": "Sync Line Timestamps",
+			"timestampTools": {
+				"index": "Timestamp",
+				"syncLineTimestamps": "Sync Line Timestamps",
+				"reduceStutter": "Reduce Stutter"
+			},
 			"perWordRomanization":
 			{
 				"index": "Per-Word Romanization",

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -324,7 +324,11 @@
 			"autoSegment": "一键分词",
 			"rubySegment": "注音分词",
 			"advancedSegment": "高级分词...",
-			"syncLineTimestamps": "同步行时间戳",
+			"timestampTools": {
+				"index": "时间戳",
+				"syncLineTimestamps": "同步行时间戳",
+				"reduceStutter": "消减卡顿"
+			},
 			"perWordRomanization": 
 			{
 				"index": "逐字音译",
@@ -554,6 +558,11 @@
 		"fromLine": "从",
 		"toLine": "行 到",
 		"line": "行"
+	},
+	"reduceStutterDialog": {
+		"title": "消减卡顿",
+		"description": "检测到以下音节间隔小于 100ms，选中项将被调整为中间时间点",
+		"noStutter": "未检测到卡顿"
 	},
 	"distributeRomanDialog": {
 		"title": "应用逐行音译到逐字",

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -562,7 +562,8 @@
 	"reduceStutterDialog": {
 		"title": "消减卡顿",
 		"description": "检测到以下音节间隔小于 100ms，选中项将被调整为中间时间点",
-		"noStutter": "未检测到卡顿"
+		"noStutter": "未检测到卡顿",
+		"play": "播放"
 	},
 	"distributeRomanDialog": {
 		"title": "应用逐行音译到逐字",

--- a/src/components/Dialogs/index.tsx
+++ b/src/components/Dialogs/index.tsx
@@ -18,6 +18,7 @@ import { RiskConfirmationDialog } from "./risk-confirmation.tsx";
 import { NotificationCenterDialog } from "./notification-center.tsx";
 import { MetaSuggestionManagerDialog } from "./meta-suggestion-manager.tsx";
 import { StorageManagerDialog } from "./storage-manager.tsx";
+import { ReduceStutterDialog } from "./reduce-stutter.tsx";
 
 export const Dialogs = () => {
 	return (
@@ -42,6 +43,7 @@ export const Dialogs = () => {
 			<RiskConfirmationDialog />
 			<MetaSuggestionManagerDialog />
 			<StorageManagerDialog />
+			<ReduceStutterDialog />
 		</>
 	);
 };

--- a/src/components/Dialogs/reduce-stutter.tsx
+++ b/src/components/Dialogs/reduce-stutter.tsx
@@ -3,13 +3,16 @@ import {
 	Checkbox,
 	Dialog,
 	Flex,
+	IconButton,
 	ScrollArea,
 	Text,
 } from "@radix-ui/themes";
+import { PlayRegular } from "@fluentui/react-icons";
 import { useAtom, useAtomValue } from "jotai";
 import { useSetImmerAtom } from "jotai-immer";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { audioEngine } from "$/modules/audio/audio-engine";
 import { reduceStutterDialogAtom } from "$/states/dialogs.ts";
 import { lyricLinesAtom } from "$/states/main.ts";
 import type { LyricWord } from "$/types/ttml";
@@ -108,6 +111,13 @@ export const ReduceStutterDialog = () => {
 		setOpen({ open: false });
 	};
 
+	const handlePlay = (pair: StutterPair) => {
+		// 播放前一个音节的开始-100ms 到后一个音节的结束+100ms
+		const startTime = Math.max(0, pair.prevWord.startTime - 100) / 1000;
+		const endTime = (pair.nextWord.endTime + 100) / 1000;
+		audioEngine.auditionRange(startTime, endTime);
+	};
+
 	return (
 		<Dialog.Root open={open.open} onOpenChange={(v) => setOpen({ open: v })}>
 			<Dialog.Content maxWidth="600px" maxHeight="80vh">
@@ -145,6 +155,14 @@ export const ReduceStutterDialog = () => {
 										checked={selectedPairs.has(index.toString())}
 										onCheckedChange={() => togglePair(index.toString())}
 									/>
+									<IconButton
+										size="1"
+										variant="soft"
+										onClick={() => handlePlay(pair)}
+										title={t("reduceStutterDialog.play", "播放")}
+									>
+										<PlayRegular />
+									</IconButton>
 									<Flex direction="column" style={{ flex: 1 }}>
 										<Text size="2">
 											{pair.prevWord.word} [

--- a/src/components/Dialogs/reduce-stutter.tsx
+++ b/src/components/Dialogs/reduce-stutter.tsx
@@ -1,0 +1,179 @@
+import {
+	Button,
+	Checkbox,
+	Dialog,
+	Flex,
+	ScrollArea,
+	Text,
+} from "@radix-ui/themes";
+import { useAtom, useAtomValue } from "jotai";
+import { useSetImmerAtom } from "jotai-immer";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { reduceStutterDialogAtom } from "$/states/dialogs.ts";
+import { lyricLinesAtom } from "$/states/main.ts";
+import type { LyricWord } from "$/types/ttml";
+import { msToTimestamp } from "$/utils/timestamp.ts";
+
+interface StutterPair {
+	lineIndex: number;
+	wordIndex: number;
+	nextWordIndex: number;
+	prevWord: LyricWord;
+	nextWord: LyricWord;
+	gap: number;
+}
+
+export const ReduceStutterDialog = () => {
+	const { t } = useTranslation();
+	const [open, setOpen] = useAtom(reduceStutterDialogAtom);
+	const lyricLines = useAtomValue(lyricLinesAtom);
+	const setLyricLines = useSetImmerAtom(lyricLinesAtom);
+	const [selectedPairs, setSelectedPairs] = useState<Set<string>>(new Set());
+
+	const stutterPairs = useMemo<StutterPair[]>(() => {
+		const pairs: StutterPair[] = [];
+		lyricLines.lyricLines.forEach((line, lineIndex) => {
+			for (let i = 0; i < line.words.length - 1; i++) {
+				const currentWord = line.words[i];
+				const nextWord = line.words[i + 1];
+				const gap = nextWord.startTime - currentWord.endTime;
+				if (gap > 0 && gap < 100) {
+					pairs.push({
+						lineIndex,
+						wordIndex: i,
+						nextWordIndex: i + 1,
+						prevWord: currentWord,
+						nextWord,
+						gap,
+					});
+				}
+			}
+		});
+		return pairs;
+	}, [lyricLines.lyricLines]);
+
+	// 当对话框打开时，默认全选所有卡顿项
+	useEffect(() => {
+		if (open.open) {
+			const allIds = new Set(stutterPairs.map((_, index) => index.toString()));
+			setSelectedPairs(allIds);
+		}
+	}, [open.open, stutterPairs]);
+
+	const togglePair = (index: string) => {
+		setSelectedPairs((prev) => {
+			const next = new Set(prev);
+			if (next.has(index)) {
+				next.delete(index);
+			} else {
+				next.add(index);
+			}
+			return next;
+		});
+	};
+
+	const handleConfirm = () => {
+		const selectedIndices = Array.from(selectedPairs).map((id) =>
+			parseInt(id, 10),
+		);
+
+		setLyricLines((draft) => {
+			selectedIndices.forEach((pairIndex) => {
+				const pair = stutterPairs[pairIndex];
+				if (!pair) return;
+
+				const line = draft.lyricLines[pair.lineIndex];
+				if (!line) return;
+
+				const prevWord = line.words[pair.wordIndex];
+				const nextWord = line.words[pair.nextWordIndex];
+				if (!prevWord || !nextWord) return;
+
+				// 计算中间时间
+				const middleTime = Math.round(
+					(prevWord.endTime + nextWord.startTime) / 2,
+				);
+
+				// 设置两个音节的边界为中间时间
+				prevWord.endTime = middleTime;
+				nextWord.startTime = middleTime;
+			});
+		});
+
+		setOpen({ open: false });
+	};
+
+	const handleClose = () => {
+		setOpen({ open: false });
+	};
+
+	return (
+		<Dialog.Root open={open.open} onOpenChange={(v) => setOpen({ open: v })}>
+			<Dialog.Content maxWidth="600px" maxHeight="80vh">
+				<Dialog.Title>
+					{t("reduceStutterDialog.title", "消减卡顿")}
+				</Dialog.Title>
+				<Dialog.Description>
+					{t(
+						"reduceStutterDialog.description",
+						"检测到以下音节间隔小于 100ms，选中项将被调整为中间时间点",
+					)}
+				</Dialog.Description>
+
+				{stutterPairs.length === 0 ? (
+					<Flex justify="center" py="4">
+						<Text color="gray">
+							{t("reduceStutterDialog.noStutter", "未检测到卡顿")}
+						</Text>
+					</Flex>
+				) : (
+					<ScrollArea style={{ maxHeight: "400px", marginTop: "16px" }}>
+						<Flex direction="column" gap="2">
+							{stutterPairs.map((pair, index) => (
+								<Flex
+									key={`${pair.lineIndex}-${pair.wordIndex}`}
+									align="center"
+									gap="2"
+									p="2"
+									style={{
+										borderRadius: "4px",
+										backgroundColor: "var(--gray-3)",
+									}}
+								>
+									<Checkbox
+										checked={selectedPairs.has(index.toString())}
+										onCheckedChange={() => togglePair(index.toString())}
+									/>
+									<Flex direction="column" style={{ flex: 1 }}>
+										<Text size="2">
+											{pair.prevWord.word} [
+											{msToTimestamp(pair.prevWord.startTime)}~
+											{msToTimestamp(pair.prevWord.endTime)}] -{" "}
+											{pair.nextWord.word} [
+											{msToTimestamp(pair.nextWord.startTime)}~
+											{msToTimestamp(pair.nextWord.endTime)}] :{" "}
+											{pair.gap} ms
+										</Text>
+									</Flex>
+								</Flex>
+							))}
+						</Flex>
+					</ScrollArea>
+				)}
+
+				<Flex gap="3" mt="4" justify="end">
+					<Button variant="soft" color="gray" onClick={handleClose}>
+						{t("common.cancel", "取消")}
+					</Button>
+					<Button
+						onClick={handleConfirm}
+						disabled={stutterPairs.length === 0 || selectedPairs.size === 0}
+					>
+						{t("common.confirm", "确认")}
+					</Button>
+				</Flex>
+			</Dialog.Content>
+		</Dialog.Root>
+	);
+};

--- a/src/components/TopMenu/modals/ToolMenu.tsx
+++ b/src/components/TopMenu/modals/ToolMenu.tsx
@@ -32,9 +32,19 @@ const ToolMenuItems = () => {
 					</DropdownMenu.Item>
 				</DropdownMenu.SubContent>
 			</DropdownMenu.Sub>
-			<DropdownMenu.Item onSelect={menu.onSyncLineTimestamps}>
-				{t("topBar.menu.syncLineTimestamps", "同步行时间戳")}
-			</DropdownMenu.Item>
+			<DropdownMenu.Sub>
+				<DropdownMenu.SubTrigger>
+					{t("topBar.menu.timestampTools.index", "时间戳")}
+				</DropdownMenu.SubTrigger>
+				<DropdownMenu.SubContent>
+					<DropdownMenu.Item onSelect={menu.onSyncLineTimestamps}>
+					{t("topBar.menu.timestampTools.syncLineTimestamps", "同步行时间戳")}
+				</DropdownMenu.Item>
+				<DropdownMenu.Item onSelect={menu.onReduceStutter}>
+					{t("topBar.menu.timestampTools.reduceStutter", "消减卡顿")}
+				</DropdownMenu.Item>
+				</DropdownMenu.SubContent>
+			</DropdownMenu.Sub>
 			<DropdownMenu.Sub>
 				<DropdownMenu.SubTrigger>
 					{t("topBar.menu.perWordRomanization.index", "逐字音译")}

--- a/src/components/TopMenu/useTopMenuActions.ts
+++ b/src/components/TopMenu/useTopMenuActions.ts
@@ -20,6 +20,7 @@ import {
 	historyRestoreDialogAtom,
 	latencyTestDialogAtom,
 	metadataEditorDialogAtom,
+	reduceStutterDialogAtom,
 	settingsDialogAtom,
 	submitToAMLLDBDialogAtom,
 	timeShiftDialogAtom,
@@ -398,6 +399,46 @@ export const useTopMenuActions = () => {
 		});
 	}, [editLyricLines, setConfirmDialog, t]);
 
+	const onAlignEndTimestamps = useCallback(() => {
+		const hasSelection = selectedLineIds.size > 0;
+
+		const action = () => {
+			editLyricLines((draft) => {
+				// 确定要处理的行：如果有选中行就处理选中行，否则处理所有行
+				const linesToProcess = hasSelection
+					? draft.lyricLines.filter((line) => selectedLineIds.has(line.id))
+					: draft.lyricLines;
+
+				for (const line of linesToProcess) {
+					if (line.words.length === 0) continue;
+
+					// 将行内最后一个音节的结束时间设置为行结束时间
+					const lastWord = line.words[line.words.length - 1];
+					lastWord.endTime = line.endTime;
+				}
+			});
+		};
+
+		setConfirmDialog({
+			open: true,
+			title: t("confirmDialog.alignEndTimestamps.title", "确认对齐尾部时间戳"),
+			description: hasSelection
+				? t(
+						"confirmDialog.alignEndTimestamps.descriptionWithSelection",
+						"此操作将把选中行的最后一个音节结束时间设置为行结束时间。确定要继续吗？",
+					)
+				: t(
+						"confirmDialog.alignEndTimestamps.description",
+						"此操作将把每行的最后一个音节结束时间设置为行结束时间。确定要继续吗？",
+					),
+			onConfirm: action,
+		});
+	}, [editLyricLines, setConfirmDialog, t, selectedLineIds]);
+
+	const onReduceStutter = useCallback(() => {
+		store.set(reduceStutterDialogAtom, { open: true });
+	}, [store]);
+
 	const onOpenDistributeRomanization = useCallback(() => {
 		setDistributeRomanizationDialog(true);
 	}, [setDistributeRomanizationDialog]);
@@ -449,6 +490,8 @@ export const useTopMenuActions = () => {
 		onRubySegment,
 		onOpenAdvancedSegmentation,
 		onSyncLineTimestamps,
+		onAlignEndTimestamps,
+		onReduceStutter,
 		onOpenDistributeRomanization,
 		onCheckRomanizationWarnings,
 		onOpenLatencyTest,

--- a/src/states/dialogs.ts
+++ b/src/states/dialogs.ts
@@ -64,3 +64,21 @@ export const reviewReportDialogAtom = atom<{
 	report: "",
 	draftId: null,
 });
+
+// 歌曲 ID 重复警告对话框
+export const duplicateSongIdDialogAtom = atom<{
+	open: boolean;
+	existingIds: { type: string; id: string }[];
+	onConfirm?: () => void;
+	onCancel?: () => void;
+}>({
+	open: false,
+	existingIds: [],
+});
+
+// 消减卡顿对话框
+export const reduceStutterDialogAtom = atom<{
+	open: boolean;
+}>({
+	open: false,
+});


### PR DESCRIPTION
在工具菜单的时间戳子菜单中添加「消减卡顿」选项：
- 遍历所有歌词行，检测相邻音节间隔小于 100ms 的卡顿项
- 显示弹窗列出所有检测到的卡顿项，默认全部选中
- 用户确认后将选中的音节对边界调整为中间时间点

涉及的文件：
- 新增 reduce-stutter.tsx 对话框组件
- 更新 ToolMenu.tsx 添加菜单项
- 更新 useTopMenuActions.ts 添加处理函数
- 更新 dialogs.ts 添加对话框状态
- 更新 translation.json 添加翻译文本