### PR TITLE
feat: 新功能-从元数据重命名

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -380,7 +380,13 @@
 		"popover": {
 			"filename": "File Name",
 			"versionHistory": "Version History..."
-		}
+		},
+		"rename": "Rename",
+		"renameFromMetadata": "Rename from Metadata",
+		"noMetadata": "No metadata",
+		"goToMetadataEditor": "Go to Metadata Editor",
+		"previewFileName": "Preview file name",
+		"insufficientMetadata": "Insufficient metadata, track name and artists are required"
 	},
 	"contextMenu": {
 		"deleteWords": "Delete {count, plural, one {word} other {words}}",

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -370,6 +370,8 @@
 		}
 	},
 	"header": {
+		"rename": "Rename",
+		"renameFromMetadata": "Rename from metadata",
 		"status": {
 			"saving": "Saving...",
 			"pending": "Saving...",
@@ -380,13 +382,7 @@
 		"popover": {
 			"filename": "File Name",
 			"versionHistory": "Version History..."
-		},
-		"rename": "Rename",
-		"renameFromMetadata": "Rename from Metadata",
-		"noMetadata": "No metadata",
-		"goToMetadataEditor": "Go to Metadata Editor",
-		"previewFileName": "Preview file name",
-		"insufficientMetadata": "Insufficient metadata, track name and artists are required"
+		}
 	},
 	"contextMenu": {
 		"deleteWords": "Delete {count, plural, one {word} other {words}}",
@@ -697,6 +693,14 @@
 		"pickSuggestion": "Select match",
 		"clear": "Clear",
 		"info": "Learn more"
+	},
+	"metadataRenameDialog": {
+		"title": "Rename from Metadata",
+		"empty": "No metadata",
+		"splayerSupport": "Enable SPlayer local lyrics support",
+		"goToMetadataEditor": "Go to metadata editor",
+		"filenamePlaceholder": "Filename",
+		"apply": "Apply"
 	},
 	"metaSuggestion": {
 		"dialogTitle": "Metadata editor",

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -375,6 +375,8 @@
 		}
 	},
 	"header": {
+		"rename": "重命名",
+		"renameFromMetadata": "从元数据重命名",
 		"status": {
 			"saving": "正在保存...",
 			"pending": "正在保存...",
@@ -385,13 +387,7 @@
 		"popover": {
 			"filename": "文件名",
 			"versionHistory": "版本历史记录..."
-		},
-		"rename": "重命名",
-		"renameFromMetadata": "从元数据重命名",
-		"noMetadata": "无元数据",
-		"goToMetadataEditor": "前往编辑元数据",
-		"previewFileName": "预览文件名",
-		"insufficientMetadata": "元数据不足，需要歌曲名称和艺术家"
+		}
 	},
 	"contextMenu": {
 		"deleteWords": "删除单词",
@@ -708,6 +704,14 @@
 		"pickSuggestion": "选择匹配项",
 		"clear": "清空",
 		"info": "了解详情"
+	},
+	"metadataRenameDialog": {
+		"title": "从元数据重命名",
+		"empty": "无任何元数据",
+		"splayerSupport": "启用 SPlayer 本地歌词支持",
+		"goToMetadataEditor": "前往编辑元数据",
+		"filenamePlaceholder": "文件名",
+		"apply": "应用"
 	},
 	"metaSuggestion": {
 		"dialogTitle": "元数据编辑器",

--- a/locales/zh-CN/translation.json
+++ b/locales/zh-CN/translation.json
@@ -385,7 +385,13 @@
 		"popover": {
 			"filename": "文件名",
 			"versionHistory": "版本历史记录..."
-		}
+		},
+		"rename": "重命名",
+		"renameFromMetadata": "从元数据重命名",
+		"noMetadata": "无元数据",
+		"goToMetadataEditor": "前往编辑元数据",
+		"previewFileName": "预览文件名",
+		"insufficientMetadata": "元数据不足，需要歌曲名称和艺术家"
 	},
 	"contextMenu": {
 		"deleteWords": "删除单词",

--- a/src/components/Dialogs/index.tsx
+++ b/src/components/Dialogs/index.tsx
@@ -6,6 +6,7 @@ import { DistributeRomanizationDialog } from "$/modules/project/modals/Distribut
 import { HistoryRestoreDialog } from "$/modules/project/modals/HistoryRestore.tsx";
 import { ImportFromText } from "$/modules/project/modals/ImportFromText.tsx";
 import { MetadataEditor } from "$/modules/project/modals/MetadataEditor.tsx";
+import { MetadataRenameDialog } from "$/modules/project/modals/MetadataRenameDialog.tsx";
 import { VocalTagsEditor } from "$/modules/project/modals/VocalTagsEditor.tsx";
 import { AgentManager } from "$/modules/project/modals/AgentManager.tsx";
 import { SubmitToAMLLDBDialog } from "$/modules/user/modals/SubmitToAmll.tsx";
@@ -28,6 +29,7 @@ export const Dialogs = () => {
 			<ImportFromText />
 			<ImportFromLRCLIB />
 			<MetadataEditor />
+			<MetadataRenameDialog />
 			<VocalTagsEditor />
 			<AgentManager />
 			<SettingsDialog />

--- a/src/components/TopMenu/HeaderFileInfo.tsx
+++ b/src/components/TopMenu/HeaderFileInfo.tsx
@@ -1,40 +1,20 @@
 import { HistoryRegular } from "@fluentui/react-icons";
-import {
-	Box,
-	Button,
-	DropdownMenu,
-	Flex,
-	ScrollArea,
-	Text,
-	TextField,
-} from "@radix-ui/themes";
+import { Box, Button, DropdownMenu, Flex, Text, TextField } from "@radix-ui/themes";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { useImmerAtom } from "jotai-immer";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { historyRestoreDialogAtom, metadataEditorDialogAtom } from "$/states/dialogs";
+import { historyRestoreDialogAtom, metadataRenameDialogAtom } from "$/states/dialogs";
 import {
 	lastSavedTimeAtom,
-	lyricLinesAtom,
 	saveFileNameAtom,
 } from "$/states/main";
-import { getSuggestedTtmlFileName } from "$/modules/project/logic/metadata-filename";
-
-const METADATA_LABELS: Record<string, { key: string; fallback: string }> = {
-	musicName: { key: "metadataDialog.builtinOptions.musicName", fallback: "歌曲名称" },
-	artists: { key: "metadataDialog.builtinOptions.artists", fallback: "歌曲的艺术家" },
-	album: { key: "metadataDialog.builtinOptions.album", fallback: "歌曲的专辑名" },
-	songwriter: { key: "metadataDialog.builtinOptions.songwriter", fallback: "词曲作者" },
-};
 
 export const HeaderFileInfo = () => {
 	const { t } = useTranslation();
 	const [filename, setFilename] = useAtom(saveFileNameAtom);
 	const lastSavedTime = useAtomValue(lastSavedTimeAtom);
 	const setHistoryDialogOpen = useSetAtom(historyRestoreDialogAtom);
-	const setMetadataEditorOpen = useSetAtom(metadataEditorDialogAtom);
-	const [lyricLines, setLyricLines] = useImmerAtom(lyricLinesAtom);
-	const metadata = lyricLines.metadata;
+	const setRenameDialog = useSetAtom(metadataRenameDialogAtom);
 	const [isEditing, setIsEditing] = useState(false);
 	const [draftName, setDraftName] = useState("");
 	const [autoSaveExpanded, setAutoSaveExpanded] = useState(false);
@@ -42,7 +22,6 @@ export const HeaderFileInfo = () => {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const lastSavedTimeRef = useRef<number | null>(null);
 	const suffix = ".ttml";
-	const suggestedFile = getSuggestedTtmlFileName(metadata);
 
 	const getBaseName = useCallback(
 		(value: string) =>
@@ -85,29 +64,6 @@ export const HeaderFileInfo = () => {
 		}, 4000);
 		return () => window.clearTimeout(timer);
 	}, [lastSavedTime]);
-
-	const handleApplyMetadataName = useCallback(() => {
-		if (suggestedFile) {
-			setFilename(suggestedFile.fileName);
-		}
-	}, [setFilename, suggestedFile]);
-
-	const handleGoToMetadataEditor = useCallback(() => {
-		setMetadataEditorOpen(true);
-	}, [setMetadataEditorOpen]);
-
-	const updateMetadataValue = useCallback(
-		(key: string, valueIndex: number, newValue: string) => {
-			setLyricLines((prev) => {
-				const entry = prev.metadata.find((m) => m.key === key);
-				if (entry && entry.value[valueIndex] !== undefined) {
-					entry.value[valueIndex] = newValue;
-					entry.autoSuggested = false;
-				}
-			});
-		},
-		[setLyricLines],
-	);
 
 	return (
 		<Flex align="center" gap="2" style={{ maxWidth: "100%" }}>
@@ -197,101 +153,12 @@ export const HeaderFileInfo = () => {
 							</Button>
 						</DropdownMenu.Trigger>
 						<DropdownMenu.Content>
-							<DropdownMenu.Item onClick={() => setIsEditing(true)}>
+							<DropdownMenu.Item onSelect={() => setIsEditing(true)}>
 								{t("header.rename", "重命名")}
 							</DropdownMenu.Item>
-							<DropdownMenu.Sub>
-								<DropdownMenu.SubTrigger>
-									{t("header.renameFromMetadata", "从元数据重命名")}
-								</DropdownMenu.SubTrigger>
-								<DropdownMenu.SubContent
-									style={{
-										maxHeight: "60vh",
-										overflowY: "auto",
-										minWidth: "280px",
-										padding: "12px",
-									}}
-								>
-									{metadata.length === 0 ? (
-										<Flex direction="column" gap="2" align="center" py="4">
-											<Text size="2" color="gray">
-												{t("header.noMetadata", "无元数据")}
-											</Text>
-											<Button
-												variant="soft"
-												size="1"
-												onClick={handleGoToMetadataEditor}
-											>
-												{t("header.goToMetadataEditor", "前往编辑元数据")}
-											</Button>
-										</Flex>
-									) : (
-										<Flex direction="column" gap="3">
-											<ScrollArea style={{ maxHeight: "40vh" }}>
-												<Flex direction="column" gap="2">
-													{metadata.map((entry) => {
-														const labelConfig = METADATA_LABELS[entry.key];
-														const label = labelConfig
-															? t(labelConfig.key, labelConfig.fallback)
-															: entry.key;
-														return (
-															<Flex
-																key={entry.key}
-																direction="column"
-																gap="1"
-															>
-																<Text size="1" weight="bold" color="gray">
-																	{label}
-																</Text>
-																{entry.value.map((val, vi) => (
-																	<TextField.Root
-																		key={`${entry.key}-${vi}`}
-																		size="1"
-																		value={val}
-																		onChange={(e) =>
-																			updateMetadataValue(
-																				entry.key,
-																				vi,
-																				e.currentTarget.value,
-																			)
-																		}
-																	/>
-																))}
-															</Flex>
-														);
-													})}
-												</Flex>
-											</ScrollArea>
-											<Flex
-												direction="column"
-												gap="2"
-												pt="2"
-												style={{
-													borderTop: "1px solid var(--gray-5)",
-												}}
-											>
-												{suggestedFile ? (
-													<>
-														<Text size="1" color="gray">
-															{t("header.previewFileName", "预览文件名")}
-														</Text>
-														<Text size="2" weight="bold">
-															{suggestedFile.fileName}
-														</Text>
-														<Button size="1" onClick={handleApplyMetadataName}>
-															{t("common.apply", "应用")}
-														</Button>
-													</>
-												) : (
-													<Text size="1" color="orange">
-														{t("header.insufficientMetadata", "元数据不足，需要歌曲名称和艺术家")}
-													</Text>
-												)}
-											</Flex>
-										</Flex>
-									)}
-								</DropdownMenu.SubContent>
-							</DropdownMenu.Sub>
+							<DropdownMenu.Item onSelect={() => setRenameDialog(true)}>
+								{t("header.renameFromMetadata", "从元数据重命名")}
+							</DropdownMenu.Item>
 						</DropdownMenu.Content>
 					</DropdownMenu.Root>
 				)}

--- a/src/components/TopMenu/HeaderFileInfo.tsx
+++ b/src/components/TopMenu/HeaderFileInfo.tsx
@@ -1,9 +1,18 @@
 import { HistoryRegular } from "@fluentui/react-icons";
-import { Box, Button, Flex, Text, TextField } from "@radix-ui/themes";
+import {
+	Box,
+	Button,
+	DropdownMenu,
+	Flex,
+	ScrollArea,
+	Text,
+	TextField,
+} from "@radix-ui/themes";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useImmerAtom } from "jotai-immer";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { confirmDialogAtom, historyRestoreDialogAtom } from "$/states/dialogs";
+import { historyRestoreDialogAtom, metadataEditorDialogAtom } from "$/states/dialogs";
 import {
 	lastSavedTimeAtom,
 	lyricLinesAtom,
@@ -11,13 +20,21 @@ import {
 } from "$/states/main";
 import { getSuggestedTtmlFileName } from "$/modules/project/logic/metadata-filename";
 
+const METADATA_LABELS: Record<string, { key: string; fallback: string }> = {
+	musicName: { key: "metadataDialog.builtinOptions.musicName", fallback: "歌曲名称" },
+	artists: { key: "metadataDialog.builtinOptions.artists", fallback: "歌曲的艺术家" },
+	album: { key: "metadataDialog.builtinOptions.album", fallback: "歌曲的专辑名" },
+	songwriter: { key: "metadataDialog.builtinOptions.songwriter", fallback: "词曲作者" },
+};
+
 export const HeaderFileInfo = () => {
 	const { t } = useTranslation();
 	const [filename, setFilename] = useAtom(saveFileNameAtom);
 	const lastSavedTime = useAtomValue(lastSavedTimeAtom);
 	const setHistoryDialogOpen = useSetAtom(historyRestoreDialogAtom);
-	const setConfirmDialog = useSetAtom(confirmDialogAtom);
-	const metadata = useAtomValue(lyricLinesAtom).metadata;
+	const setMetadataEditorOpen = useSetAtom(metadataEditorDialogAtom);
+	const [lyricLines, setLyricLines] = useImmerAtom(lyricLinesAtom);
+	const metadata = lyricLines.metadata;
 	const [isEditing, setIsEditing] = useState(false);
 	const [draftName, setDraftName] = useState("");
 	const [autoSaveExpanded, setAutoSaveExpanded] = useState(false);
@@ -69,25 +86,28 @@ export const HeaderFileInfo = () => {
 		return () => window.clearTimeout(timer);
 	}, [lastSavedTime]);
 
-	const handleNameClick = useCallback(() => {
-		const isDefaultName = filename.toLowerCase() === "lyric.ttml";
-		if (isDefaultName && suggestedFile) {
-			setConfirmDialog({
-				open: true,
-				title: t("confirmDialog.useMetadataName.title", "使用元数据命名？"),
-				description: t(
-					"confirmDialog.useMetadataName.description",
-					'是否使用"{name}"作为文件名？',
-					{ name: suggestedFile.baseName },
-				),
-				onConfirm: () => {
-					setFilename(suggestedFile.fileName);
-				},
-			});
-			return;
+	const handleApplyMetadataName = useCallback(() => {
+		if (suggestedFile) {
+			setFilename(suggestedFile.fileName);
 		}
-		setIsEditing(true);
-	}, [filename, setConfirmDialog, setFilename, suggestedFile, t]);
+	}, [setFilename, suggestedFile]);
+
+	const handleGoToMetadataEditor = useCallback(() => {
+		setMetadataEditorOpen(true);
+	}, [setMetadataEditorOpen]);
+
+	const updateMetadataValue = useCallback(
+		(key: string, valueIndex: number, newValue: string) => {
+			setLyricLines((prev) => {
+				const entry = prev.metadata.find((m) => m.key === key);
+				if (entry && entry.value[valueIndex] !== undefined) {
+					entry.value[valueIndex] = newValue;
+					entry.autoSuggested = false;
+				}
+			});
+		},
+		[setLyricLines],
+	);
 
 	return (
 		<Flex align="center" gap="2" style={{ maxWidth: "100%" }}>
@@ -139,41 +159,141 @@ export const HeaderFileInfo = () => {
 						<Text size="2">{suffix}</Text>
 					</Flex>
 				) : (
-					<Button
-						variant="ghost"
-						color="gray"
-						style={{
-							height: "auto",
-							padding: "6px 10px",
-							fontWeight: "normal",
-							color: "var(--gray-12)",
-							maxWidth: "100%",
-						}}
-						onClick={handleNameClick}
-					>
-						<Flex align="center" gap="2" style={{ maxWidth: "100%" }}>
-							<Flex
-								align="center"
+					<DropdownMenu.Root>
+						<DropdownMenu.Trigger>
+							<Button
+								variant="ghost"
+								color="gray"
 								style={{
-									maxWidth: "10rem",
-									overflow: "hidden",
-									whiteSpace: "nowrap",
+									height: "auto",
+									padding: "6px 10px",
+									fontWeight: "normal",
+									color: "var(--gray-12)",
+									maxWidth: "100%",
 								}}
 							>
-								<Text
-									weight="bold"
-									size="2"
+								<Flex align="center" gap="2" style={{ maxWidth: "100%" }}>
+									<Flex
+										align="center"
+										style={{
+											maxWidth: "10rem",
+											overflow: "hidden",
+											whiteSpace: "nowrap",
+										}}
+									>
+										<Text
+											weight="bold"
+											size="2"
+											style={{
+												overflow: "hidden",
+												textOverflow: "ellipsis",
+											}}
+										>
+											{getBaseName(filename)}
+										</Text>
+										<Text size="2">{suffix}</Text>
+									</Flex>
+								</Flex>
+							</Button>
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content>
+							<DropdownMenu.Item onClick={() => setIsEditing(true)}>
+								{t("header.rename", "重命名")}
+							</DropdownMenu.Item>
+							<DropdownMenu.Sub>
+								<DropdownMenu.SubTrigger>
+									{t("header.renameFromMetadata", "从元数据重命名")}
+								</DropdownMenu.SubTrigger>
+								<DropdownMenu.SubContent
 									style={{
-										overflow: "hidden",
-										textOverflow: "ellipsis",
+										maxHeight: "60vh",
+										overflowY: "auto",
+										minWidth: "280px",
+										padding: "12px",
 									}}
 								>
-									{getBaseName(filename)}
-								</Text>
-								<Text size="2">{suffix}</Text>
-							</Flex>
-						</Flex>
-					</Button>
+									{metadata.length === 0 ? (
+										<Flex direction="column" gap="2" align="center" py="4">
+											<Text size="2" color="gray">
+												{t("header.noMetadata", "无元数据")}
+											</Text>
+											<Button
+												variant="soft"
+												size="1"
+												onClick={handleGoToMetadataEditor}
+											>
+												{t("header.goToMetadataEditor", "前往编辑元数据")}
+											</Button>
+										</Flex>
+									) : (
+										<Flex direction="column" gap="3">
+											<ScrollArea style={{ maxHeight: "40vh" }}>
+												<Flex direction="column" gap="2">
+													{metadata.map((entry) => {
+														const labelConfig = METADATA_LABELS[entry.key];
+														const label = labelConfig
+															? t(labelConfig.key, labelConfig.fallback)
+															: entry.key;
+														return (
+															<Flex
+																key={entry.key}
+																direction="column"
+																gap="1"
+															>
+																<Text size="1" weight="bold" color="gray">
+																	{label}
+																</Text>
+																{entry.value.map((val, vi) => (
+																	<TextField.Root
+																		key={`${entry.key}-${vi}`}
+																		size="1"
+																		value={val}
+																		onChange={(e) =>
+																			updateMetadataValue(
+																				entry.key,
+																				vi,
+																				e.currentTarget.value,
+																			)
+																		}
+																	/>
+																))}
+															</Flex>
+														);
+													})}
+												</Flex>
+											</ScrollArea>
+											<Flex
+												direction="column"
+												gap="2"
+												pt="2"
+												style={{
+													borderTop: "1px solid var(--gray-5)",
+												}}
+											>
+												{suggestedFile ? (
+													<>
+														<Text size="1" color="gray">
+															{t("header.previewFileName", "预览文件名")}
+														</Text>
+														<Text size="2" weight="bold">
+															{suggestedFile.fileName}
+														</Text>
+														<Button size="1" onClick={handleApplyMetadataName}>
+															{t("common.apply", "应用")}
+														</Button>
+													</>
+												) : (
+													<Text size="1" color="orange">
+														{t("header.insufficientMetadata", "元数据不足，需要歌曲名称和艺术家")}
+													</Text>
+												)}
+											</Flex>
+										</Flex>
+									)}
+								</DropdownMenu.SubContent>
+							</DropdownMenu.Sub>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
 				)}
 			</Box>
 		</Flex>

--- a/src/modules/project/modals/MetadataRenameDialog.module.css
+++ b/src/modules/project/modals/MetadataRenameDialog.module.css
@@ -1,0 +1,30 @@
+.dialogContent {
+	max-width: 560px;
+	max-height: 90vh;
+	display: flex;
+	flex-direction: column;
+	padding: 0;
+	overflow: hidden;
+}
+
+.dialogHeader {
+	padding: 20px 20px 10px 20px;
+	flex-shrink: 0;
+}
+
+.dialogBody {
+	flex: 1;
+	overflow-y: auto;
+	padding: 0 20px 10px 20px;
+}
+
+.dialogFooter {
+	padding: 16px 20px;
+	border-top: 1px solid var(--gray-5);
+	flex-shrink: 0;
+	background: var(--color-bg-1);
+}
+
+.metadataGroup {
+	margin-bottom: 12px;
+}

--- a/src/modules/project/modals/MetadataRenameDialog.tsx
+++ b/src/modules/project/modals/MetadataRenameDialog.tsx
@@ -1,0 +1,283 @@
+import {
+	AlbumRegular,
+	Info16Regular,
+	MusicNote1Regular,
+	NumberSymbol16Regular,
+	Person16Regular,
+} from "@fluentui/react-icons";
+import { Button, Checkbox, Dialog, Flex, Text, TextField } from "@radix-ui/themes";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { type ReactNode, useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+	AppleMusicIcon,
+	GithubIcon,
+	NeteaseIcon,
+	QQMusicIcon,
+	SpotifyIcon,
+} from "$/modules/project/modals/PlatformIcons";
+import {
+	metadataEditorDialogAtom,
+	metadataRenameDialogAtom,
+} from "$/states/dialogs";
+import { lyricLinesAtom, saveFileNameAtom } from "$/states/main";
+import type { TTMLMetadata } from "$/types/ttml";
+import styles from "./MetadataRenameDialog.module.css";
+
+interface MetadataKeyOption {
+	key: string;
+	label: string;
+	icon: ReactNode;
+}
+
+export const MetadataRenameDialog = () => {
+	const [open, setOpen] = useAtom(metadataRenameDialogAtom);
+	const setFilename = useSetAtom(saveFileNameAtom);
+	const metadata = useAtomValue(lyricLinesAtom).metadata;
+	const setMetadataEditorDialog = useSetAtom(metadataEditorDialogAtom);
+	const { t } = useTranslation();
+
+	const suffix = ".ttml";
+	const [draftName, setDraftName] = useState("");
+	const [splayerEnabled, setSplayerEnabled] = useState(false);
+
+	const hasNcmMusicId = useMemo(
+		() =>
+			metadata.some(
+				(entry) =>
+					entry.key === "ncmMusicId" &&
+					entry.value.some((v) => v.trim() !== ""),
+			),
+		[metadata],
+	);
+
+	const metadataKeyOptions: MetadataKeyOption[] = useMemo(
+		() => [
+			{
+				key: "musicName",
+				label: t("metadataDialog.builtinOptions.musicName", "歌曲名称"),
+				icon: <MusicNote1Regular />,
+			},
+			{
+				key: "artists",
+				label: t("metadataDialog.builtinOptions.artists", "歌曲的艺术家"),
+				icon: <Person16Regular />,
+			},
+			{
+				key: "songwriter",
+				label: t("metadataDialog.builtinOptions.songwriter", "词曲作者"),
+				icon: <Person16Regular />,
+			},
+			{
+				key: "album",
+				label: t("metadataDialog.builtinOptions.album", "歌曲的专辑名"),
+				icon: <AlbumRegular />,
+			},
+			{
+				key: "ncmMusicId",
+				label: t("metadataDialog.builtinOptions.ncmMusicId", "网易云音乐 ID"),
+				icon: <NeteaseIcon />,
+			},
+			{
+				key: "qqMusicId",
+				label: t("metadataDialog.builtinOptions.qqMusicId", "QQ 音乐 ID"),
+				icon: <QQMusicIcon />,
+			},
+			{
+				key: "spotifyId",
+				label: t("metadataDialog.builtinOptions.spotifyId", "Spotify 音乐 ID"),
+				icon: <SpotifyIcon />,
+			},
+			{
+				key: "appleMusicId",
+				label: t(
+					"metadataDialog.builtinOptions.appleMusicId",
+					"Apple Music 音乐 ID",
+				),
+				icon: <AppleMusicIcon />,
+			},
+			{
+				key: "isrc",
+				label: t("metadataDialog.builtinOptions.isrc", "歌曲的 ISRC 号码"),
+				icon: <NumberSymbol16Regular />,
+			},
+			{
+				key: "ttmlAuthorGithub",
+				label: t(
+					"metadataDialog.builtinOptions.ttmlAuthorGithub",
+					"歌词作者 GitHub ID",
+				),
+				icon: <GithubIcon />,
+			},
+			{
+				key: "ttmlAuthorGithubLogin",
+				label: t(
+					"metadataDialog.builtinOptions.ttmlAuthorGithubLogin",
+					"歌词作者 GitHub 用户名",
+				),
+				icon: <GithubIcon />,
+			},
+		],
+		[t],
+	);
+
+	const findOption = useCallback(
+		(key: string) => metadataKeyOptions.find((o) => o.key === key),
+		[metadataKeyOptions],
+	);
+
+	const handleOpenChange = useCallback(
+		(isOpen: boolean) => {
+			setOpen(isOpen);
+			if (isOpen) {
+				setDraftName("");
+				setSplayerEnabled(false);
+			}
+		},
+		[setOpen],
+	);
+
+	const handleMetadataClick = useCallback(
+		(entry: TTMLMetadata, value: string) => {
+			const trimmed = value.trim();
+			if (!trimmed) return;
+			if (splayerEnabled && entry.key === "ncmMusicId") {
+				setDraftName((prev) => prev + "." + trimmed);
+			} else {
+				setDraftName((prev) => prev + trimmed);
+			}
+		},
+		[splayerEnabled],
+	);
+
+	const handleApply = useCallback(() => {
+		const trimmed = draftName.trim();
+		if (trimmed.length > 0) {
+			setFilename(`${trimmed}${suffix}`);
+		}
+		setOpen(false);
+	}, [draftName, setFilename, setOpen]);
+
+	const handleGoToMetadataEditor = useCallback(() => {
+		setOpen(false);
+		setMetadataEditorDialog(true);
+	}, [setOpen, setMetadataEditorDialog]);
+
+	const filteredMetadata = useMemo(
+		() =>
+			metadata.filter((entry) => entry.value.some((v) => v.trim() !== "")),
+		[metadata],
+	);
+
+	return (
+		<Dialog.Root open={open} onOpenChange={handleOpenChange}>
+			<Dialog.Content className={styles.dialogContent}>
+				<div className={styles.dialogHeader}>
+					<Dialog.Title style={{ margin: 0 }}>
+						{t("metadataRenameDialog.title", "从元数据重命名")}
+					</Dialog.Title>
+				</div>
+
+				<div className={styles.dialogBody}>
+					{filteredMetadata.length === 0 && (
+						<Text
+							color="gray"
+							style={{
+								textAlign: "center",
+								display: "block",
+								padding: "2em 0",
+							}}
+						>
+							{t("metadataRenameDialog.empty", "无任何元数据")}
+						</Text>
+					)}
+					{filteredMetadata.map((entry) => {
+						const option = findOption(entry.key);
+						const nonEmptyValues = entry.value.filter(
+							(v) => v.trim() !== "",
+						);
+						return (
+							<div key={entry.key} className={styles.metadataGroup}>
+								<Flex align="center" gap="1" mb="1">
+									<span
+										style={{ display: "flex", color: "var(--gray-12)" }}
+									>
+										{option?.icon || <Info16Regular />}
+									</span>
+									<Text size="2" weight="bold">
+										{option?.label || entry.key}
+									</Text>
+								</Flex>
+								<Flex gap="1" wrap="wrap">
+									{nonEmptyValues.map((value, index) => (
+										<Button
+											key={`${entry.key}-${index}`}
+											variant="soft"
+											size="1"
+											onClick={() =>
+												handleMetadataClick(entry, value)
+											}
+										>
+											{value}
+										</Button>
+									))}
+								</Flex>
+							</div>
+						);
+					})}
+					<Flex direction="column" gap="2" mt="3">
+						<Flex align="center" gap="2">
+							<Checkbox
+								checked={splayerEnabled}
+								onCheckedChange={(v) =>
+									setSplayerEnabled(v === true)
+								}
+								disabled={!hasNcmMusicId}
+							/>
+							<Text
+								size="2"
+								color={!hasNcmMusicId ? "gray" : undefined}
+							>
+								{t(
+									"metadataRenameDialog.splayerSupport",
+									"启用 SPlayer 本地歌词支持",
+								)}
+							</Text>
+						</Flex>
+						<Button
+							variant="soft"
+							onClick={handleGoToMetadataEditor}
+						>
+							{t(
+								"metadataRenameDialog.goToMetadataEditor",
+								"前往编辑元数据",
+							)}
+						</Button>
+					</Flex>
+				</div>
+
+				<Flex align="center" gap="2" className={styles.dialogFooter}>
+					<TextField.Root
+						size="2"
+						value={draftName}
+						onChange={(e) => setDraftName(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") {
+								handleApply();
+							}
+						}}
+						placeholder={t(
+							"metadataRenameDialog.filenamePlaceholder",
+							"文件名",
+						)}
+						style={{ flex: 1 }}
+					/>
+					<Text size="2">{suffix}</Text>
+					<Button onClick={handleApply}>
+						{t("metadataRenameDialog.apply", "应用")}
+					</Button>
+				</Flex>
+			</Dialog.Content>
+		</Dialog.Root>
+	);
+};

--- a/src/states/dialogs.ts
+++ b/src/states/dialogs.ts
@@ -3,6 +3,7 @@ import type { ReviewReport } from "$/modules/review/services/report-service";
 
 export const importFromTextDialogAtom = atom(false);
 export const metadataEditorDialogAtom = atom(false);
+export const metadataRenameDialogAtom = atom(false);
 export const vocalTagsEditorDialogAtom = atom(false);
 export const metaSuggestionManagerDialogAtom = atom(false);
 export const storageManagerDialogAtom = atom(false);


### PR DESCRIPTION
~~（散猫不会写描述）~~

1. 文件名按钮新增下拉菜单，支持重命名与从元数据重命名，普通重命名直入编辑输入框
​
2. 元数据重命名唤起独立弹窗，展示全部元数据条目为独立按钮，多值元数据拆分多按钮；进入界面清空原文件名，点击元数据向后追加内容，底部支持文件名预览编辑与应用
​
3. 新增「启用SPlayer本地歌词支持」勾选框，仅存在网易云音乐歌曲ID时可用，开启后点击网易云音乐歌曲ID追加 .歌曲ID 格式适配歌词文件命名
​
4. 新增「前往编辑元数据」快捷操作按钮

（请使用变基合并，提交 '77af209' 测试失败）
（本 PR 纯 Vibe Coding）

效果图：
<img width="1920" height="1080" alt="Image_1779121033366_341" src="https://github.com/user-attachments/assets/924c97c8-021e-439a-a93c-04acb10b1bd5" />
